### PR TITLE
fix batch size logging

### DIFF
--- a/flower_classifier/train.py
+++ b/flower_classifier/train.py
@@ -14,7 +14,12 @@ from flower_classifier.models.classifier import FlowerClassifier
 @hydra.main(config_path="../conf", config_name="config")
 def train(cfg):
     data_module = hydra.utils.instantiate(cfg.dataset)
-    model = FlowerClassifier(**cfg.model, optimizer_config=cfg.optimizer, lr_scheduler_config=cfg.lr_scheduler)
+    model = FlowerClassifier(
+        **cfg.model,
+        optimizer_config=cfg.optimizer,
+        lr_scheduler_config=cfg.lr_scheduler,
+        batch_size=cfg.dataset.batch_size
+    )
 
     logger = hydra.utils.instantiate(cfg.trainer.logger) or False
     experiment = getattr(logger, "experiment", None)


### PR DESCRIPTION
WandB was logging the incorrect batch size value. This is because I didn't pass in the batch_size argument when creating the model, so it was using the class default.