### PR TITLE
more clear learning rate config

### DIFF
--- a/conf/lr_scheduler/onecycle.yaml
+++ b/conf/lr_scheduler/onecycle.yaml
@@ -1,7 +1,7 @@
 # @package _group_
 scheduler:
   _target_: torch.optim.lr_scheduler.OneCycleLR
-  max_lr: ${model.learning_rate}
+  max_lr: ${optimizer.lr}
   total_steps: 20000
 interval: step
 frequency: 1

--- a/conf/model/default.yaml
+++ b/conf/model/default.yaml
@@ -1,5 +1,4 @@
 # @package _group_
 architecture: resnet34
-learning_rate: 0.001
 dropout_rate: 0.4
 global_pool: avg

--- a/conf/optimizer/adam.yaml
+++ b/conf/optimizer/adam.yaml
@@ -1,3 +1,3 @@
 # @package _group_
 _target_: torch.optim.Adam
-lr: ${model.learning_rate}
+lr: 0.001

--- a/conf/optimizer/sgd.yaml
+++ b/conf/optimizer/sgd.yaml
@@ -1,3 +1,4 @@
 # @package _group_
 _target_: torch.optim.SGD
-lr: ${model.learning_rate}
+lr: 0.1
+momentum: 0.9

--- a/flower_classifier/models/classifier.py
+++ b/flower_classifier/models/classifier.py
@@ -14,7 +14,7 @@ from flower_classifier.visualizations import generate_confusion_matrix
 logger = logging.getLogger(__name__)
 
 # add default for cases where we don't initialize with hydra main
-DEFAULT_OPTIMIZER = OmegaConf.create({"_target_": "torch.optim.Adam", "lr": "0.001"})
+DEFAULT_OPTIMIZER = OmegaConf.create({"_target_": "torch.optim.Adam", "lr": 0.001})
 
 
 class FlowerClassifier(pl.LightningModule):
@@ -91,11 +91,10 @@ class FlowerClassifier(pl.LightningModule):
 
     def configure_optimizers(self):
         optimizer = hydra.utils.instantiate(self.optimizer_config, params=self.parameters())
-        scheduler = hydra.utils.instantiate(self.lr_scheduler_config.scheduler, optimizer=optimizer)
-
-        if scheduler is None:
+        if self.lr_scheduler_config is None:
             return optimizer
 
+        scheduler = hydra.utils.instantiate(self.lr_scheduler_config.scheduler, optimizer=optimizer)
         scheduler_dict = OmegaConf.to_container(self.lr_scheduler_config, resolve=True)
         scheduler_dict["scheduler"] = scheduler
         return [optimizer], [scheduler_dict]

--- a/flower_classifier/train.py
+++ b/flower_classifier/train.py
@@ -14,7 +14,12 @@ from flower_classifier.models.classifier import FlowerClassifier
 @hydra.main(config_path="../conf", config_name="config")
 def train(cfg):
     data_module = hydra.utils.instantiate(cfg.dataset)
-    model = FlowerClassifier(**cfg.model, optimizer_config=cfg.optimizer, lr_scheduler_config=cfg.lr_scheduler)
+    model = FlowerClassifier(
+        **cfg.model,
+        optimizer_config=cfg.optimizer,
+        lr_scheduler_config=cfg.lr_scheduler,
+        batch_size=cfg.dataset.batch_size
+    )
 
     logger = hydra.utils.instantiate(cfg.trainer.logger) or False
     experiment = getattr(logger, "experiment", None)

--- a/tests/models/test_train.py
+++ b/tests/models/test_train.py
@@ -6,7 +6,7 @@ from flower_classifier.models.classifier import FlowerClassifier
 
 @pytest.fixture(scope="module")
 def lightning_module() -> pl.LightningModule:
-    model = FlowerClassifier(architecture="resnet34", learning_rate=0.01)
+    model = FlowerClassifier(architecture="resnet34")
     return model
 
 


### PR DESCRIPTION
## What does this PR do?

We were only using the model `learning_rate` attribute to ensure that it was logged, but now that we're logging all of the optimizer config we should only specify the learning rate in the optimizer config.