### PR TITLE
split dataset in datamodule

### DIFF
--- a/flower_classifier/datasets/csv.py
+++ b/flower_classifier/datasets/csv.py
@@ -4,6 +4,7 @@ in `flower_classifier/datasets/oxford_flowers.py`. This splits the original data
 into a train and validation split. With separate datasets, you can apply different
 transformation pipelines.
 """
+from pathlib import Path
 
 import pandas as pd
 import pytorch_lightning as pl
@@ -11,7 +12,9 @@ import torch
 import torchvision
 from PIL import Image
 
+from flower_classifier import ROOT_DATA_DIR
 from flower_classifier.datasets.oxford_flowers import NAMES as oxford_idx_to_names
+from flower_classifier.datasets.oxford_flowers import split_dataset
 
 
 class CSVDataset(torch.utils.data.Dataset):
@@ -48,8 +51,8 @@ class CSVDataset(torch.utils.data.Dataset):
 class CSVDataModule(pl.LightningDataModule):
     def __init__(
         self,
-        train_csv: str = "/content/drive/My Drive/Flowers/oxford102/train_split.csv",
-        val_csv: str = "/content/drive/My Drive/Flowers/oxford102/val_split.csv",
+        data_dir=ROOT_DATA_DIR,
+        val_size=0.1,
         train_transforms=[],
         val_transforms=[],
         batch_size=16,
@@ -59,6 +62,12 @@ class CSVDataModule(pl.LightningDataModule):
     ):
         super().__init__()
         self.batch_size = batch_size
+        self.root_dir = Path(data_dir)
+        self.csv_dir = self.root_dir / "oxford102"
+        split_dataset(self.root_dir, self.csv_dir, val_size=val_size)
+        train_csv = self.csv_dir / "train_split.csv"
+        val_csv = self.csv_dir / "val_split.csv"
+
         self.train_dataset = CSVDataset(
             filename=train_csv,
             data_col=data_col,

--- a/flower_classifier/datasets/oxford_flowers.py
+++ b/flower_classifier/datasets/oxford_flowers.py
@@ -141,7 +141,7 @@ def download_dataset(root_dir: str):
         torchvision.datasets.utils.download_url(LABELS_URL, root_dir)
 
 
-def split_dataset(root_dir: str, target_dir: str, test_size=0.2, download=False):
+def split_dataset(root_dir: str, target_dir: str, val_size=0.1, download=False):
     """
     Creates two CSVs with filepaths to the images in the original dataset.
     """
@@ -157,7 +157,7 @@ def split_dataset(root_dir: str, target_dir: str, test_size=0.2, download=False)
     labels = loadmat(labels_filename)["labels"].flatten() - 1
     filepaths = [root_dir / "jpg" / f"image_{index+1:05}.jpg" for index in range(len(labels))]
     X_train, X_val, y_train, y_val = train_test_split(
-        filepaths, labels, test_size=test_size, random_state=14, stratify=labels
+        filepaths, labels, test_size=val_size, random_state=14, stratify=labels
     )
 
     train_dataset = {"filename": X_train, "label": y_train}
@@ -218,10 +218,10 @@ class OxfordFlowersDataModule(pl.LightningDataModule):
         self.train_sampler = SubsetRandomSampler(train_idx)
         self.val_sampler = SubsetRandomSampler(valid_idx)
 
-    def get_sampler_indices(self, valid_size=0.1, shuffle=True, random_seed=14):
+    def get_sampler_indices(self, val_size=0.1, shuffle=True, random_seed=14):
         num_train = len(self.dataset)
         indices = list(range(num_train))
-        split = int(np.floor(valid_size * num_train))
+        split = int(np.floor(val_size * num_train))
 
         if shuffle:
             np.random.seed(random_seed)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,9 @@
-import os
-
 import pytest
 import torch
 import torchvision
 
-from flower_classifier.datasets.csv import CSVDataset
-from flower_classifier.datasets.oxford_flowers import OxfordFlowers102Dataset, OxfordFlowersDataModule, split_dataset
+from flower_classifier.datasets.csv import CSVDataModule
+from flower_classifier.datasets.oxford_flowers import OxfordFlowers102Dataset, OxfordFlowersDataModule
 from flower_classifier.datasets.random import RandomDataModule
 from tests.datasets import TEST_CACHE_DIR
 
@@ -39,22 +37,16 @@ def oxford_datamodule():
 
 
 @pytest.fixture(scope="module")
-def oxford_csv_dataset() -> torch.utils.data.Dataset:
-    split_dataset(root_dir=TEST_CACHE_DIR, target_dir=TEST_CACHE_DIR)
-    train_filename = os.path.join(TEST_CACHE_DIR, "train_split.csv")
+def oxford_csv_datamodule():
     transforms = [
         torchvision.transforms.RandomResizedCrop(224),
         torchvision.transforms.ToTensor(),
         torchvision.transforms.Normalize([0.485, 0.456, 0.406], [0.229, 0.224, 0.225]),
     ]
-    dataset = CSVDataset(filename=train_filename, transforms=transforms)
-    return dataset
-
-
-@pytest.fixture(scope="module")
-def oxford_csv_dataloader(oxford_csv_dataset):
-    dataloader = torch.utils.data.DataLoader(oxford_csv_dataset, batch_size=8, shuffle=False)
-    return dataloader
+    data_module = CSVDataModule(
+        data_dir=TEST_CACHE_DIR, batch_size=32, train_transforms=transforms, val_transforms=transforms
+    )
+    return data_module
 
 
 @pytest.fixture(scope="module")

--- a/tests/models/test_train.py
+++ b/tests/models/test_train.py
@@ -31,8 +31,8 @@ def test_training_step_datamodule(lightning_module, trainer, oxford_datamodule):
 
 
 @pytest.mark.download
-def test_training_step_csv_dataloader(lightning_module, trainer, oxford_csv_dataloader):
-    trainer.fit(lightning_module, train_dataloader=oxford_csv_dataloader, val_dataloaders=oxford_csv_dataloader)
+def test_training_step_csv_dataloader(lightning_module, trainer, oxford_csv_datamodule):
+    trainer.fit(lightning_module, datamodule=oxford_csv_datamodule)
 
 
 def test_training_step_offline(lightning_module, trainer, random_datamodule):


### PR DESCRIPTION
## What does this PR do?

Trades off generality for convenience. Mirrors the API for OxfordFlowersDataModule (pass in the root data dir) and performs the dataset split during initialization. Previously, it was expected that you perform the split manually in advance of creating the object.
