### PR TITLE
torch cuda compat on colab

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt -f https://download.pytorch.org/whl/torch_stable.html
+          pip install -r requirements.txt
           pip install -r requirements-dev.txt
       - name: Lint with flake8
         run: |

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 init:
 	pip install --upgrade -r requirements-dev.txt
-	pip install -e . -f https://download.pytorch.org/whl/torch_stable.html
+	pip install -e .
 	pre-commit install
 
 format:
@@ -16,6 +16,7 @@ check:
 
 colab: init
 	cp .vscode/default_settings.json .vscode/settings.json
+	pip install --upgrade -r requirements-colab.txt -f https://download.pytorch.org/whl/torch_stable.html
 	sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-key C99B11DEB97541F0
 	sudo apt-add-repository https://cli.github.com/packages
 	sudo apt update

--- a/requirements-colab.txt
+++ b/requirements-colab.txt
@@ -1,0 +1,2 @@
+torch==1.7.0+cu101
+torchvision==0.8.1+cu101

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ scikit-learn==0.23.2
 scipy>=1.5.0
 streamlit==0.71
 timm==0.2.1
-torch==1.7.0+cu101
-torchvision==0.8.1+cu101
+torch==1.7.0
+torchvision==0.8.1
 typer==0.3.2
 wandb==0.10.5


### PR DESCRIPTION
## What does this PR do?

Changes default requirements to use the standard `torch` wheel, only installs the cuda 10.1 binary when building on Colab. This fixes our streamlit deployment since they don't use the `--find-links` option when building the app.
